### PR TITLE
Fix onClick Syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ class DropdownTreeSelect extends Component {
         }}
       >
         <div className="dropdown">
-          <a className={dropdownTriggerClassname} onClick={!this.props.disabled && this.handleClick}>
+          <a className={dropdownTriggerClassname} onClick={!this.props.disabled ? this.handleClick : undefined}>
             <Input
               inputRef={el => {
                 this.searchInput = el

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -30,7 +30,7 @@ class Tag extends PureComponent {
       ? tagRenderer(originalObject, this.handleClick)
       : <span className={cx('tag')}>
         {label}
-        <button onClick={!readOnly && this.handleClick} className={cx('tag-remove', { readOnly })} type="button">
+        <button onClick={!readOnly ? this.handleClick : undefined} className={cx('tag-remove', { readOnly })} type="button">
           x
         </button>
       </span>

--- a/src/tree-node/action.js
+++ b/src/tree-node/action.js
@@ -23,7 +23,7 @@ class Action extends PureComponent {
     const { title, className, text, readOnly } = this.props
 
     return (
-      <i title={title} className={className} onClick={!readOnly && this.handleClick}>
+      <i title={title} className={className} onClick={!readOnly ? this.handleClick : undefined}>
         {text}
       </i>
     )


### PR DESCRIPTION
## Summary
- When implementing react-testing-library specs we got this error when adding `readOnly` prop to the component
```
  Warning: Expected `onClick` listener to be a function, instead got `false`.

    If you used to conditionally omit it with onClick={condition && value}, pass onClick={condition ? value : undefined} instead.
        at button
        at span

      38 |
      39 | const GroupedMultiSelect = ({
    > 40 |     labels: labelsProp,
         |     ^
      41 |     groups: groupsProp,
      42 |     path,
      43 |     formProps,
```

- This PR fixes the `onClick` syntax